### PR TITLE
Fix issue with float appearing as a string.

### DIFF
--- a/app/models/rateitapp/ratable.rb
+++ b/app/models/rateitapp/ratable.rb
@@ -10,7 +10,7 @@ module Rateitapp
     end
 
     def average
-      Rating.where(ratable_type: @type, ratable_id: @id).average(:value)
+      Rating.where(ratable_type: @type, ratable_id: @id).average(:value).to_f
     end
 
     def count

--- a/features/step_definitions/json_api_average.rb
+++ b/features/step_definitions/json_api_average.rb
@@ -9,7 +9,7 @@ end
 
 Then(/^I should get that song's average rating$/) do
   json = JSON.parse(page.body)
-  expect(json.first['average']).to eq '3.0'
+  expect(json.first['average']).to eq 3.0
 end
 
 Given(/^a set of ratings for several songs$/) do
@@ -25,7 +25,7 @@ end
 Then(/^I should get those songs' average ratings$/) do
   json = JSON.parse(page.body)
   json.each do |item|
-    expect(item['average']).to eq '3.5'
+    expect(item['average']).to eq 3.5
   end
 end
 

--- a/spec/models/rateitapp/ratable_spec.rb
+++ b/spec/models/rateitapp/ratable_spec.rb
@@ -43,6 +43,12 @@ module Rateitapp
       subject { ratable.average }
 
       it { is_expected.to eq 3.5 }
+
+      # Rails encodes BigDecimal as a JSON string to avoid precision loss when
+      # poorly behaved clients convert to float. Given the nature of this value,
+      # the precision is superfluous and the string is annoying. So make this a
+      # float.
+      it { is_expected.to be_instance_of Float }
     end
   end
 end


### PR DESCRIPTION
Rails encodes BigDecimal as a JSON string to avoid precision loss when poorly behaved clients convert to float. Given the nature of this value, the precision is superfluous and the string is annoying. So make this a float.
