### PR TITLE
Move OAuth from api to engine/gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
+  gem 'webmock'
 end
 
 group :test, :development do

--- a/app/controllers/rateitapp/ratings_controller.rb
+++ b/app/controllers/rateitapp/ratings_controller.rb
@@ -4,6 +4,8 @@ require_dependency 'rateitapp/application_controller'
 module Rateitapp
   # Controller for actions involving ratings.
   class RatingsController < ApplicationController
+    before_action :authenticate_user
+
     MAX_SHOW_REQUESTS = 50
 
     def index
@@ -46,6 +48,17 @@ module Rateitapp
 
     def rating_params
       params.permit(:user_id, :ratable_type, :ratable_id)
+    end
+
+    def authenticate_user
+      access_token = bearer_token
+      Rateitapp.oauth_plugin.validate_access_token(access_token) if access_token
+    end
+
+    def bearer_token
+      pattern = /^Bearer /
+      header = request.headers['Authorization']
+      header.gsub(pattern, '') if header && header.match(pattern)
     end
   end
 end

--- a/app/models/rateitapp/oauth_plugin.rb
+++ b/app/models/rateitapp/oauth_plugin.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'immutable-struct'
+
+module Rateitapp
+  # A plugin for the OAuth.
+  class OauthPlugin
+    Response = ImmutableStruct.new(:valid?, :uid)
+
+    def validate_access_token(access_token)
+      # Form request
+      uri = URI("https://#{Rateitapp.oauth_domain}/oauth/token/info")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{access_token}"
+
+      # Get response
+      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        res_body = JSON.parse(res.body)
+        Response.new(valid: true, uid: res_body['uid'])
+      else
+        Response.new(valid: false, uid: nil)
+      end
+    end
+  end
+end

--- a/config/initializers/rateit_app.rb
+++ b/config/initializers/rateit_app.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
 # Rateitapp.plugin_manager.add('name_of_your_plugin')
+Rateitapp.oauth_domain = 'accounts.publicradio.org'

--- a/lib/rateitapp.rb
+++ b/lib/rateitapp.rb
@@ -4,4 +4,5 @@ require 'rateitapp/plugins'
 
 # Engine namespace
 module Rateitapp
+  mattr_accessor :oauth_domain
 end

--- a/lib/rateitapp/plugins.rb
+++ b/lib/rateitapp/plugins.rb
@@ -5,4 +5,8 @@ module Rateitapp
   def self.plugin_manager
     @plugin_manager ||= PluginManager.new
   end
+
+  def self.oauth_plugin
+    OauthPlugin.new
+  end
 end

--- a/rateitapp.gemspec
+++ b/rateitapp.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2'
   s.add_dependency 'active_model_serializers', '~> 0.10.0'
   s.add_dependency 'kaminari', '~> 0.17.0'
+  s.add_dependency 'oauth2'
+  s.add_dependency 'immutable-struct'
 
   s.add_development_dependency 'mysql2'
 end

--- a/spec/models/rateitapp/oauth_manager_spec.rb
+++ b/spec/models/rateitapp/oauth_manager_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+module Rateitapp
+  RSpec.describe OauthPlugin do
+    describe '#validate_access_token' do
+      let(:oauth_plugin) { OauthPlugin.new }
+      let(:access_token) { '0a9aaeb432c0a270835438195281328f75078ed0' }
+
+      before(:each) do
+        stub_request(:get, 'https://accounts.publicradio.org/oauth/token/info')
+          .with(headers: {
+                  'Authorization': 'Bearer 0a9aaeb432c0a270835438195281328f75078ed0',
+                  'Host': 'accounts.publicradio.org'
+                })
+          .to_return(status: 200,
+                     body: {
+                       'uid': '0a9aaeb432c0a270835438195281328f75078ed0',
+                       'role': 'admin',
+                       'expires_at': "\u0004\bI\"\u001e2032-12-18 12:31:19 -0600\u0006:\rencoding\"\u000fISO-8859-1"
+                     }.to_json,
+                     headers: {})
+
+        stub_request(:get, 'https://accounts.publicradio.org/oauth/token/info')
+          .with(headers: {
+                  'Authorization' => 'Bearer 1231231231231231231231231231231231231231',
+                  'Host' => 'accounts.publicradio.org'
+                })
+          .to_return(status: 401, body: '', headers: {})
+      end
+
+      subject { oauth_plugin.validate_access_token(access_token) }
+
+      context 'with an authorized access token' do
+        it { is_expected.to be_valid }
+        it 'has expected response uid' do
+          expect(subject.uid).to eq access_token
+        end
+      end
+
+      context 'with an unauthorized access token' do
+        let(:access_token) { '1231231231231231231231231231231231231231' }
+
+        it 'is invalid' do
+          expect(subject.valid?).to eq false
+        end
+        it 'has no response uid' do
+          expect(subject.uid).to eq nil
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 require 'factory_girl'
+require 'webmock/rspec'
 
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryGirl.find_definitions


### PR DESCRIPTION
Move Oauth Plugin from the API to the RateIt engine. Add necessary gems and tests.
